### PR TITLE
Support grafana

### DIFF
--- a/service-chain-aws/deploy-4scn/README.md
+++ b/service-chain-aws/deploy-4scn/README.md
@@ -67,7 +67,7 @@ It creates SCN, EN instance nodes with [CentOS AMI](https://aws.amazon.com/marke
 | scn\_subnet\_ids | A list of subnets to place SCN instance nodes. It could be better set to private subnet if it need to run without public IPs | `list(string)` | n/a | yes |
 | security\_group | Security group name to attach SCN and EN instance nodes | `string` | `"ServiceChain-common"` | no |
 | ssh\_client\_ips | A list of CIDRs to access SCN, EN instance nodes by SSH | `list(string)` | n/a | yes |
-| ssh\_pub\_key | SSH Public key to access SCN instance nodes, EN instance nodes | `string` | n/a | yes |
+| ssh\_pub\_key | SSH Public key to access SCN, EN, grafana instance nodes | `string` | n/a | yes |
 | tags | A map of tags to add to all resources | `map` | `{}` | no |
 | vpc\_id | VPC id where the SCN, EN instance nodes will be created | `string` | n/a | yes |
 

--- a/service-chain-aws/deploy-4scn/README.md
+++ b/service-chain-aws/deploy-4scn/README.md
@@ -20,7 +20,7 @@ module "klaytn-service-chain" {
 }
 ```
 
-Or simply edit [terraform.tfvars](https://github.com/klaytn/klaytn-terraform/blob/master/serivce-chain-aws/terraform.tfvars) and fill each element. Then run `terraform init / plan / apply` to create resources in AWS.
+Or simply edit [terraform.tfvars](https://github.com/klaytn/klaytn-terraform/blob/master/serivce-chain-aws/deploy-4scn/terraform.tfvars) and fill each element. Then run `terraform init / plan / apply` to create resources in AWS.
 
 
 ## with VPC module example
@@ -54,6 +54,10 @@ It creates SCN, EN instance nodes with [CentOS AMI](https://aws.amazon.com/marke
 | en\_instance\_count | The Number of EN node | `number` | `1` | no |
 | en\_instance\_type | EN instance node type | `string` | `"m5.2xlarge"` | no |
 | en\_subnet\_ids | A list of subnets to place EN instance nodes. It usually set to public subnet contrary to scn\_subnet\_ids | `list(string)` | n/a | yes |
+| grafana\_ebs\_volume\_size | EBS volume size to attach grafana nodes. Default volume indicate minimum size in klaytn docs | `number` | `500` | no |
+| grafana\_instance\_count | The Number of grafana node | `number` | `1` | no |
+| grafana\_instance\_type | Grafana instance node type | `string` | `"m5.xlarge"` | no |
+| grafana\_subnet\_ids | A list of subnets to place grafana instance nodes. It should be set to public subnet in order to access the grafana web UI via browser | `list(string)` | n/a | yes |
 | name | Name of every resource's name tag | `string` | `"test"` | no |
 | region | Region where all resources will be created | `string` | `"ap-northeast-2"` | no |
 | scn\_ebs\_volume\_size | EBS volume size to attach SCN nodes | `number` | `50` | no |

--- a/service-chain-aws/deploy-4scn/grafana.tf
+++ b/service-chain-aws/deploy-4scn/grafana.tf
@@ -1,0 +1,58 @@
+resource "aws_instance" "grafana" {
+  count                       = var.grafana_instance_count
+  ami                         = data.aws_ami.node_ami.id
+  instance_type               = var.grafana_instance_type
+  vpc_security_group_ids      = [aws_security_group.common.id]
+  associate_public_ip_address = true
+  key_name                    = aws_key_pair.common.key_name
+  subnet_id                   = var.grafana_subnet_ids[count.index % length(var.grafana_subnet_ids)]
+
+  root_block_device {
+    volume_type = "gp2"
+  }
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-grafana-${count.index + 1}"
+  })
+
+  lifecycle {
+    # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
+    ignore_changes = [ami]
+  }
+}
+
+resource "aws_ebs_volume" "grafana_data" {
+  count             = var.grafana_instance_count
+  availability_zone = aws_instance.grafana[count.index].availability_zone
+  size              = var.grafana_ebs_volume_size
+  type              = "gp2"
+
+  tags = merge(var.tags, {
+    Name = "${var.name}-grafana-${count.index + 1}"
+  })
+}
+
+resource "aws_volume_attachment" "grafana_data" {
+  count       = var.grafana_instance_count
+  volume_id   = aws_ebs_volume.grafana_data[count.index].id
+  instance_id = aws_instance.grafana[count.index].id
+  device_name = "/dev/sdb"
+}
+
+resource "aws_eip" "grafana" {
+  count = var.grafana_instance_count
+  vpc   = true
+  tags = merge(var.tags, {
+    Name = "${var.name}-grafana-${count.index + 1}"
+  })
+
+  lifecycle {
+    prevent_destroy = false
+  }
+}
+
+resource "aws_eip_association" "grafana" {
+  count         = var.grafana_instance_count
+  instance_id   = aws_instance.grafana[count.index].id
+  allocation_id = aws_eip.grafana[count.index].id
+}

--- a/service-chain-aws/deploy-4scn/output.tf
+++ b/service-chain-aws/deploy-4scn/output.tf
@@ -14,3 +14,7 @@ output "en_public_ip_addr" {
   description = "EN instance nodes' public ip. It might help create inventory file when it comes to use ansible"
   value       = ["${aws_eip.en.*.public_ip}"]
 }
+output "grafana_public_ip_addr" {
+  description = "Grafana instance nodes' public ip. It might help create inventory file when it comes to use ansible"
+  value       = ["${aws_eip.grafana.*.public_ip}"]
+}

--- a/service-chain-aws/deploy-4scn/scn_node.tf
+++ b/service-chain-aws/deploy-4scn/scn_node.tf
@@ -125,6 +125,15 @@ resource "aws_security_group_rule" "ingress_anchoring_network_tcp" {
   source_security_group_id = aws_security_group.common.id
 }
 
+resource "aws_security_group_rule" "ingress_grafana_tcp" {
+  security_group_id        = aws_security_group.common.id
+  type                     = "ingress"
+  from_port                = 61001
+  to_port                  = 61001
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.common.id
+}
+
 resource "aws_security_group_rule" "ingress_scn_eip_network_tcp" {
   count                    = var.scn_public_ip ? var.scn_instance_count : 0
   security_group_id        = aws_security_group.common.id
@@ -185,11 +194,30 @@ resource "aws_security_group_rule" "ingress_en_eip_network_udp" {
   cidr_blocks              = ["${aws_eip.en[count.index].public_ip}/32"]
 }
 
+resource "aws_security_group_rule" "ingress_grafana_public_tcp" {
+  count                    = var.grafana_instance_count
+  security_group_id        = aws_security_group.common.id
+  type                     = "ingress"
+  from_port                = 61001
+  to_port                  = 61001
+  protocol                 = "tcp"
+  cidr_blocks              = ["${aws_eip.grafana[count.index].public_ip}/32"]
+}
+
 resource "aws_security_group_rule" "ingress_network_rpc" {
   security_group_id = aws_security_group.common.id
   type              = "ingress"
   from_port         = 8551
   to_port           = 8551
+  protocol          = "tcp"
+  cidr_blocks       = var.ssh_client_ips
+}
+
+resource "aws_security_group_rule" "ingress_grafana_dashboard" {
+  security_group_id = aws_security_group.common.id
+  type              = "ingress"
+  from_port         = 3000
+  to_port           = 3000
   protocol          = "tcp"
   cidr_blocks       = var.ssh_client_ips
 }

--- a/service-chain-aws/deploy-4scn/terraform.tfvars
+++ b/service-chain-aws/deploy-4scn/terraform.tfvars
@@ -4,5 +4,5 @@
 # en_subnet_ids  = ["", ""]   # A list of subnets to place EN instance nodes. It usually set to public subnet contrary to scn_subnet_ids
 # grafana_subnet_ids  = ["", ""]   # A list of subnets to place grafana instance nodes. It should be set to public subnet in order to access grafana web UI via browser
 # vpc_id         = ""   # VPC id where the SCN, EN instance nodes will be created
-# ssh_client_ips = [""] # A list of CIDRs to access SCN, EN instance nodes by SSH
+# ssh_client_ips = [""] # A list of CIDRs to access SCN, EN, grafana instance nodes by SSH
 # ssh_pub_key    = ""   # SSH Public key to access SCN instance nodes, EN instance nodes

--- a/service-chain-aws/deploy-4scn/terraform.tfvars
+++ b/service-chain-aws/deploy-4scn/terraform.tfvars
@@ -2,6 +2,7 @@
 # region         = ""   # AWS region name to create all resources
 # scn_subnet_ids = ["", ""]   # A list of subnets to place SCN instance nodes. It could be better set to private subnet if it need to run without public IPs
 # en_subnet_ids  = ["", ""]   # A list of subnets to place EN instance nodes. It usually set to public subnet contrary to scn_subnet_ids
+# grafana_subnet_ids  = ["", ""]   # A list of subnets to place grafana instance nodes. It should be set to public subnet in order to access grafana web UI via browser
 # vpc_id         = ""   # VPC id where the SCN, EN instance nodes will be created
 # ssh_client_ips = [""] # A list of CIDRs to access SCN, EN instance nodes by SSH
 # ssh_pub_key    = ""   # SSH Public key to access SCN instance nodes, EN instance nodes

--- a/service-chain-aws/deploy-4scn/variables.tf
+++ b/service-chain-aws/deploy-4scn/variables.tf
@@ -8,6 +8,11 @@ variable "en_instance_count" {
   default     = 1
 }
 
+variable "grafana_instance_count" {
+  description = "The Number of grafana node"
+  default     = 1
+}
+
 variable "en_instance_type" {
   description = "EN instance node type"
   default     = "m5.2xlarge"
@@ -18,8 +23,18 @@ variable "scn_instance_type" {
   default     = "m5.xlarge"
 }
 
+variable "grafana_instance_type" {
+  description = "Grafana instance node type"
+  default     = "m5.xlarge"
+}
+
 variable "scn_subnet_ids" {
   description = "A list of subnets to place SCN instance nodes. It could be better set to private subnet if it need to run without public IPs"
+  type        = list(string)
+}
+
+variable "grafana_subnet_ids" {
+  description = "A list of subnets to place grafana instance nodes. It could be better set to private subnet if it need to run without public IPs"
   type        = list(string)
 }
 
@@ -54,6 +69,11 @@ variable "region" {
   description = "Region where all resources will be created"
   default     = "ap-northeast-2"
   type        = string
+}
+
+variable "grafana_ebs_volume_size" {
+  description = "EBS volume size to attach grafana nodes"
+  default     = 50
 }
 
 variable "scn_ebs_volume_size" {


### PR DESCRIPTION
This PR adds support for creating VMs for grafana.

The following features are added:
- Opens port 61001 because grafana uses that port to collect metrics
- Opens port 3000 for grafana web UI
- Added new variable `grafana_ebs_volume_size` `grafana_instance_count`, `grafana_instance_type`, and `grafana_subnet_ids`.