### PR TITLE
Add terraform for creating new VPC

### DIFF
--- a/serivce-chain-aws/create_vpc/main.tf
+++ b/serivce-chain-aws/create_vpc/main.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = "ap-northeast-2"
+}
+
+locals {
+  name = "service-chain-test"
+  tags = {
+    Terraform   = "true"
+    Environment = "service-chain-vpc"
+  }
+}
+
+module "vpc" {
+  source = "terraform-aws-modules/vpc/aws"
+
+  name               = local.name
+  cidr               = "10.0.0.0/16"
+  azs                = ["ap-northeast-2a", "ap-northeast-2c"]
+  private_subnets    = ["10.0.1.0/24", "10.0.2.0/24"]
+  public_subnets     = ["10.0.101.0/24", "10.0.102.0/24"]
+  enable_nat_gateway = true
+  tags               = local.tags
+}

--- a/serivce-chain-aws/create_vpc/output.tf
+++ b/serivce-chain-aws/create_vpc/output.tf
@@ -1,0 +1,14 @@
+output "vpc_id" {
+  description = "Created VPC's ID"
+  value = module.vpc.vpc_id
+}
+
+output "public_subnet_ids" {
+  description = "Created public subnets' IDs"
+  value = module.vpc.public_subnets
+}
+
+output "private_subnet_ids" {
+  description = "Created private subnets' IDs"
+  value = module.vpc.private_subnets
+}


### PR DESCRIPTION
This PR adds additional terraform to create new VPC. The user can create new VPC using this terraform project, then continue to create VMs for Klaytn nodes.

The reason to separate two terraform project (one for VPC and the other for Klaytn nodes) is to allow users to perform the latter (deploying Klaytn nodes) multiple times without creating a new VPC every time.

The contents of this additional terraform project is copied from the `example/with_vpc/main.tf` file however the original file cannot be directly used because it imports the terraform project for creating Klaytn nodes (it always creates VPC then deploy Klaytn node together).