### PR TITLE
Fix storage and AMI

### DIFF
--- a/service-chain-aws/deploy-4scn/README.md
+++ b/service-chain-aws/deploy-4scn/README.md
@@ -35,8 +35,6 @@ This module does not create network resourcse such as the VPC/subnet. This could
 | terraform | >= 0.12 |
 | aws | ~> 2.43 |
 
-It creates SCN, EN instance nodes with [CentOS AMI](https://aws.amazon.com/marketplace/pp/Centosorg-CentOS-7-x8664-with-Updates-HVM/B00O7WM7QW#pdp-usage) in AWS marketplace. You need to accept the terms and subscribe before running terraform apply.
-
 
 ## Providers
 

--- a/service-chain-aws/deploy-4scn/en_node.tf
+++ b/service-chain-aws/deploy-4scn/en_node.tf
@@ -1,10 +1,10 @@
 data "aws_ami" "en_ami" {
   most_recent = true
-  owners      = [428948643293]
+  owners      = [402311685496]
 
   filter {
     name   = "name"
-    values = ["baobab-clean-en-ami-*"]
+    values = ["baobab-clean-full-en-*"]
   }
 }
 

--- a/service-chain-aws/deploy-4scn/grafana.tf
+++ b/service-chain-aws/deploy-4scn/grafana.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "grafana" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.grafana_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "grafana" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "grafana_data" {
-  count             = var.grafana_instance_count
-  availability_zone = aws_instance.grafana[count.index].availability_zone
-  size              = var.grafana_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-grafana-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "grafana_data" {
-  count       = var.grafana_instance_count
-  volume_id   = aws_ebs_volume.grafana_data[count.index].id
-  instance_id = aws_instance.grafana[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "grafana" {

--- a/service-chain-aws/deploy-4scn/scn_node.tf
+++ b/service-chain-aws/deploy-4scn/scn_node.tf
@@ -1,25 +1,13 @@
 data "aws_ami" "node_ami" {
   most_recent = true
-  owners      = ["aws-marketplace"]
-
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "image-type"
-    values = ["machine"]
+    name   = "owner-alias"
+    values = ["amazon"]
   }
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7*"]
+    values = ["amzn2-ami-hvm*"]
   }
 }
 
@@ -34,6 +22,7 @@ resource "aws_instance" "scn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.scn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -44,24 +33,6 @@ resource "aws_instance" "scn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "scn_data" {
-  count             = var.scn_instance_count
-  availability_zone = aws_instance.scn[count.index].availability_zone
-  size              = var.scn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-scn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "scn_data" {
-  count       = var.scn_instance_count
-  volume_id   = aws_ebs_volume.scn_data[count.index].id
-  instance_id = aws_instance.scn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "scn" {

--- a/service-chain-aws/deploy-L1-L2/README.md
+++ b/service-chain-aws/deploy-L1-L2/README.md
@@ -34,8 +34,6 @@ This module does not create network resourcse such as the VPC/subnet. This could
 | terraform | >= 0.12 |
 | aws | ~> 2.43 |
 
-It creates CN, PN, EN, SCN, SPN, SEN instance nodes with [CentOS AMI](https://aws.amazon.com/marketplace/pp/Centosorg-CentOS-7-x8664-with-Updates-HVM/B00O7WM7QW#pdp-usage) in AWS marketplace. You need to accept the terms and subscribe before running terraform apply.
-
 
 ## Providers
 

--- a/service-chain-aws/deploy-L1-L2/cn_node.tf
+++ b/service-chain-aws/deploy-L1-L2/cn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "cn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.cn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "cn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "cn_data" {
-  count             = var.cn_instance_count
-  availability_zone = aws_instance.cn[count.index].availability_zone
-  size              = var.cn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-cn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "cn_data" {
-  count       = var.cn_instance_count
-  volume_id   = aws_ebs_volume.cn_data[count.index].id
-  instance_id = aws_instance.cn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "cn" {

--- a/service-chain-aws/deploy-L1-L2/common.tf
+++ b/service-chain-aws/deploy-L1-L2/common.tf
@@ -1,25 +1,13 @@
 data "aws_ami" "node_ami" {
   most_recent = true
-  owners      = ["aws-marketplace"]
-
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "image-type"
-    values = ["machine"]
+    name   = "owner-alias"
+    values = ["amazon"]
   }
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7*"]
+    values = ["amzn2-ami-hvm*"]
   }
 }
 

--- a/service-chain-aws/deploy-L1-L2/en_node.tf
+++ b/service-chain-aws/deploy-L1-L2/en_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "en" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.en_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "en" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "en_data" {
-  count             = var.en_instance_count
-  availability_zone = aws_instance.en[count.index].availability_zone
-  size              = var.en_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-en-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "en_data" {
-  count       = var.en_instance_count
-  volume_id   = aws_ebs_volume.en_data[count.index].id
-  instance_id = aws_instance.en[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "en" {

--- a/service-chain-aws/deploy-L1-L2/pn_node.tf
+++ b/service-chain-aws/deploy-L1-L2/pn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "pn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.pn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "pn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "pn_data" {
-  count             = var.pn_instance_count
-  availability_zone = aws_instance.pn[count.index].availability_zone
-  size              = var.pn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-pn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "pn_data" {
-  count       = var.pn_instance_count
-  volume_id   = aws_ebs_volume.pn_data[count.index].id
-  instance_id = aws_instance.pn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "pn" {

--- a/service-chain-aws/deploy-L1-L2/scn_node.tf
+++ b/service-chain-aws/deploy-L1-L2/scn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "scn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.scn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "scn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "scn_data" {
-  count             = var.scn_instance_count
-  availability_zone = aws_instance.scn[count.index].availability_zone
-  size              = var.scn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-scn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "scn_data" {
-  count       = var.scn_instance_count
-  volume_id   = aws_ebs_volume.scn_data[count.index].id
-  instance_id = aws_instance.scn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "scn" {

--- a/service-chain-aws/deploy-L1-L2/sen_node.tf
+++ b/service-chain-aws/deploy-L1-L2/sen_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "sen" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.sen_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "sen" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "sen_data" {
-  count             = var.sen_instance_count
-  availability_zone = aws_instance.sen[count.index].availability_zone
-  size              = var.sen_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-sen-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "sen_data" {
-  count       = var.sen_instance_count
-  volume_id   = aws_ebs_volume.sen_data[count.index].id
-  instance_id = aws_instance.sen[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "sen" {

--- a/service-chain-aws/deploy-L1-L2/spn_node.tf
+++ b/service-chain-aws/deploy-L1-L2/spn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "spn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.spn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "spn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "spn_data" {
-  count             = var.spn_instance_count
-  availability_zone = aws_instance.spn[count.index].availability_zone
-  size              = var.spn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-spn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "spn_data" {
-  count       = var.spn_instance_count
-  volume_id   = aws_ebs_volume.spn_data[count.index].id
-  instance_id = aws_instance.spn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "spn" {

--- a/service-chain-aws/deploy-multi_layer-servicechain/README.md
+++ b/service-chain-aws/deploy-multi_layer-servicechain/README.md
@@ -35,8 +35,6 @@ This module does not create network resourcse such as the VPC/subnet. This could
 | terraform | >= 0.12 |
 | aws | ~> 2.43 |
 
-It creates SCN, EN instance nodes with [CentOS AMI](https://aws.amazon.com/marketplace/pp/Centosorg-CentOS-7-x8664-with-Updates-HVM/B00O7WM7QW#pdp-usage) in AWS marketplace. You need to accept the terms and subscribe before running terraform apply.
-
 
 ## Providers
 

--- a/service-chain-aws/deploy-multi_layer-servicechain/common.tf
+++ b/service-chain-aws/deploy-multi_layer-servicechain/common.tf
@@ -1,25 +1,13 @@
 data "aws_ami" "node_ami" {
   most_recent = true
-  owners      = ["aws-marketplace"]
-
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "image-type"
-    values = ["machine"]
+    name   = "owner-alias"
+    values = ["amazon"]
   }
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7*"]
+    values = ["amzn2-ami-hvm*"]
   }
 }
 

--- a/service-chain-aws/deploy-multi_layer-servicechain/scn_node.tf
+++ b/service-chain-aws/deploy-multi_layer-servicechain/scn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "scn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.scn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "scn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "scn_data" {
-  count             = var.scn_instance_count
-  availability_zone = aws_instance.scn[count.index].availability_zone
-  size              = var.scn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-scn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "scn_data" {
-  count       = var.scn_instance_count
-  volume_id   = aws_ebs_volume.scn_data[count.index].id
-  instance_id = aws_instance.scn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "scn" {

--- a/service-chain-aws/deploy-multi_layer-servicechain/sen_node.tf
+++ b/service-chain-aws/deploy-multi_layer-servicechain/sen_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "sen" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.sen_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "sen" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "sen_data" {
-  count             = var.sen_instance_count
-  availability_zone = aws_instance.sen[count.index].availability_zone
-  size              = var.sen_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-sen-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "sen_data" {
-  count       = var.sen_instance_count
-  volume_id   = aws_ebs_volume.sen_data[count.index].id
-  instance_id = aws_instance.sen[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "sen" {

--- a/service-chain-aws/deploy-multi_layer-servicechain/spn_node.tf
+++ b/service-chain-aws/deploy-multi_layer-servicechain/spn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "spn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.spn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "spn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "spn_data" {
-  count             = var.spn_instance_count
-  availability_zone = aws_instance.spn[count.index].availability_zone
-  size              = var.spn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-spn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "spn_data" {
-  count       = var.spn_instance_count
-  volume_id   = aws_ebs_volume.spn_data[count.index].id
-  instance_id = aws_instance.spn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "spn" {

--- a/service-chain-aws/deploy-scn-spn-sen/README.md
+++ b/service-chain-aws/deploy-scn-spn-sen/README.md
@@ -35,8 +35,6 @@ This module does not create network resourcse such as the VPC/subnet. This could
 | terraform | >= 0.12 |
 | aws | ~> 2.43 |
 
-It creates SCN, EN instance nodes with [CentOS AMI](https://aws.amazon.com/marketplace/pp/Centosorg-CentOS-7-x8664-with-Updates-HVM/B00O7WM7QW#pdp-usage) in AWS marketplace. You need to accept the terms and subscribe before running terraform apply.
-
 
 ## Providers
 

--- a/service-chain-aws/deploy-scn-spn-sen/common.tf
+++ b/service-chain-aws/deploy-scn-spn-sen/common.tf
@@ -1,25 +1,13 @@
 data "aws_ami" "node_ami" {
   most_recent = true
-  owners      = ["aws-marketplace"]
-
   filter {
-    name   = "virtualization-type"
-    values = ["hvm"]
-  }
-
-  filter {
-    name   = "architecture"
-    values = ["x86_64"]
-  }
-
-  filter {
-    name   = "image-type"
-    values = ["machine"]
+    name   = "owner-alias"
+    values = ["amazon"]
   }
 
   filter {
     name   = "name"
-    values = ["CentOS Linux 7*"]
+    values = ["amzn2-ami-hvm*"]
   }
 }
 

--- a/service-chain-aws/deploy-scn-spn-sen/en_node.tf
+++ b/service-chain-aws/deploy-scn-spn-sen/en_node.tf
@@ -1,10 +1,10 @@
 data "aws_ami" "en_ami" {
   most_recent = true
-  owners      = [428948643293]
+  owners      = [402311685496]
 
   filter {
     name   = "name"
-    values = ["baobab-clean-en-ami-*"]
+    values = ["baobab-clean-full-en-*"]
   }
 }
 

--- a/service-chain-aws/deploy-scn-spn-sen/scn_node.tf
+++ b/service-chain-aws/deploy-scn-spn-sen/scn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "scn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.scn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "scn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "scn_data" {
-  count             = var.scn_instance_count
-  availability_zone = aws_instance.scn[count.index].availability_zone
-  size              = var.scn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-scn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "scn_data" {
-  count       = var.scn_instance_count
-  volume_id   = aws_ebs_volume.scn_data[count.index].id
-  instance_id = aws_instance.scn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "scn" {

--- a/service-chain-aws/deploy-scn-spn-sen/sen_node.tf
+++ b/service-chain-aws/deploy-scn-spn-sen/sen_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "sen" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.sen_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "sen" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "sen_data" {
-  count             = var.sen_instance_count
-  availability_zone = aws_instance.sen[count.index].availability_zone
-  size              = var.sen_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-sen-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "sen_data" {
-  count       = var.sen_instance_count
-  volume_id   = aws_ebs_volume.sen_data[count.index].id
-  instance_id = aws_instance.sen[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "sen" {

--- a/service-chain-aws/deploy-scn-spn-sen/spn_node.tf
+++ b/service-chain-aws/deploy-scn-spn-sen/spn_node.tf
@@ -9,6 +9,7 @@ resource "aws_instance" "spn" {
 
   root_block_device {
     volume_type = "gp2"
+    volume_size = var.spn_ebs_volume_size
   }
 
   tags = merge(var.tags, {
@@ -19,24 +20,6 @@ resource "aws_instance" "spn" {
     # Don't replace the node when the AMI is updated -- it can simply be upgraded separately
     ignore_changes = [ami]
   }
-}
-
-resource "aws_ebs_volume" "spn_data" {
-  count             = var.spn_instance_count
-  availability_zone = aws_instance.spn[count.index].availability_zone
-  size              = var.spn_ebs_volume_size
-  type              = "gp2"
-
-  tags = merge(var.tags, {
-    Name = "${var.name}-spn-${count.index + 1}"
-  })
-}
-
-resource "aws_volume_attachment" "spn_data" {
-  count       = var.spn_instance_count
-  volume_id   = aws_ebs_volume.spn_data[count.index].id
-  instance_id = aws_instance.spn[count.index].id
-  device_name = "/dev/sdb"
 }
 
 resource "aws_eip" "spn" {


### PR DESCRIPTION
This PR includes the following:
- Many VMs are provisioned with an additional EBS (disk) however those disks were neither mounted nor used. So removed the creation and attachment of additional EBS.
- Fix Baobab EN AMI owner and name
- Replace CentOS with Amazon Linux because Amazon Linux AMI does not require any manual subscription.